### PR TITLE
Fix workflow and pin OpenAI version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,1 +1,0 @@
-name: Deploy React App

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,10 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
-          
+
+      - name: Clear npm cache
+        run: npm cache clean --force
+
       - name: Install Dependencies
         working-directory: ./client
         run: npm ci

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
-        "openai": "^4.29.0",
+        "openai": "4.28.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.0",
         "firebase": "^9.22.0",
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.29.0.tgz",
-      "integrity": "sha512-placeholder",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.28.0.tgz",
+      "integrity": "sha512-TODO",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "openai": "^4.29.0",
+    "openai": "4.28.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",
     "firebase": "^9.22.0",

--- a/client/src/services/openaiService.js
+++ b/client/src/services/openaiService.js
@@ -39,7 +39,7 @@ export const sendMessageToOpenAI = async (message, knowledgeBase = '') => {
     chatHistory.push({ role: 'user', content: prompt });
 
     const response = await openai.chat.completions.create({
-      model: 'gpt-4o', // ChatGPT 4.1 mini
+      model: 'gpt-4o', // use OpenAI gpt-4o model
       messages: chatHistory,
       temperature: 0.7,
       max_tokens: 800,


### PR DESCRIPTION
## Summary
- pin openai dependency to 4.28.0
- update lockfile accordingly (integrity placeholder due to no network)
- clear npm cache before installing dependencies in CI

## Testing
- `npm install` *(failed: EHOSTUNREACH)*
- `npm test -- --watchAll=false` *(failed: react-scripts not found)*